### PR TITLE
Switch SSL off for db connection. Fix debug options.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,4 @@ COPY . /project
 RUN  cd /project && mvn package
 
 #run the spring boot application
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-Dblabla", "-jar","/project/target/demo-0.0.1-SNAPSHOT.jar"]
-
-
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom", "-jar","/project/target/demo-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -20,7 +20,8 @@ services:
       context: .
       dockerfile: Dockerfile_debug
     ports:
-      - "18080:8080"
+      - "18080:8080" # For HTTP requests
+      - "5005:5005"  # For debugging
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -3,11 +3,11 @@
 #don't forget in compose run config set=true "--build/force build images"
 
 #create a network and add our services into this network:
-#so, "app" service will be able to connect to the mysql database from "db" servoce by the hostname="db":
-#jdbc:mysql://db:3306/DOCKERDB
+#so, "app" service will be able to connect to the mysql database from "db" service by the hostname="db":
+#jdbc:mysql://db:3306/DOCKERDB?useSSL=false
 
 #Connection url for connection in the DatabaseView:
-#  jdbc:mysql://0.0.0.0:13306/DOCKERDB, login=root, password=root
+#  jdbc:mysql://0.0.0.0:13306/DOCKERDB?useSSL=false, login=root, password=root
 #App is available at: http://localhost:18080/entitybus/post
 version: "2.1"
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.jpa.hibernate.ddl-auto=none
 #use it for running all (app and db) in docker containers:
-spring.datasource.url=jdbc:mysql://db:3306/DOCKERDB
+spring.datasource.url=jdbc:mysql://db:3306/DOCKERDB?useSSL=false
 
 #use it for running app from Idea, but with db from docker image:
 #spring.datasource.url=jdbc:mysql://0.0.0.0:23306/DOCKERDB


### PR DESCRIPTION
Fix for this

> WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.

Additionally, fixed debug port mapping. Only after this (and containers rebuilding) this example finally begin working as expected.